### PR TITLE
Don't generate a version code when the commit history is not complete

### DIFF
--- a/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
+++ b/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
@@ -47,7 +47,7 @@ public open class GitVersioner internal constructor(
      */
     public val versionCode: Int by lazy {
         var code = -1 // default, this is actually a valid android versionCode
-        if (gitInfoExtractor.isGitProjectReady) {
+        if (gitInfoExtractor.isGitProjectCorrectlyInitialized) {
             val commitComponent = baseBranchCommits.size
             code = commitComponent + timeComponent
         }
@@ -70,7 +70,7 @@ public open class GitVersioner internal constructor(
      */
     public val versionName: String by lazy {
         var name = "undefined"
-        if (gitInfoExtractor.isGitProjectReady) {
+        if (gitInfoExtractor.isGitProjectCorrectlyInitialized) {
             name = try {
                 formatter(this).toString()
             } catch (e: Throwable) {
@@ -86,14 +86,14 @@ public open class GitVersioner internal constructor(
      * the current local changes (files changed, additions, deletions). [NO_CHANGES] when no changes detected
      */
     public val localChanges: LocalChanges by lazy {
-        if (!gitInfoExtractor.isGitProjectReady) NO_CHANGES else gitInfoExtractor.localChanges
+        if (!gitInfoExtractor.isGitProjectCorrectlyInitialized) NO_CHANGES else gitInfoExtractor.localChanges
     }
 
     /**
      * the name of the branch HEAD is currently on
      */
     public val branchName: String? get() {
-        if (!gitInfoExtractor.isGitProjectReady) return null
+        if (!gitInfoExtractor.isGitProjectCorrectlyInitialized) return null
         return gitInfoExtractor.currentBranch ?: ciBranchNameProvider()?.toString()
     }
 
@@ -128,7 +128,7 @@ public open class GitVersioner internal constructor(
      * [yearFactor] based time component from initial commit to [featureBranchOriginCommit]
      */
     public val timeComponent: Int by lazy {
-        if (!gitInfoExtractor.isGitProjectReady) return@lazy 0
+        if (!gitInfoExtractor.isGitProjectCorrectlyInitialized) return@lazy 0
         val latestBaseCommit = featureBranchOriginCommit ?: return@lazy 0
 
         val timeToHead = gitInfoExtractor.commitDate(
@@ -151,7 +151,10 @@ public open class GitVersioner internal constructor(
     /**
      * whether git can be used to extract data
      */
-    public val isGitInitialized: Boolean = gitInfoExtractor.isGitProjectReady
+    public val isGitProjectCorrectlyInitialized: Boolean = gitInfoExtractor.isGitProjectCorrectlyInitialized
+
+
+    public val isHistoryShallowed: Boolean = gitInfoExtractor.isHistoryShallowed
 
     /**
      * commits of base branch in history of current commit (HEAD).

--- a/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
+++ b/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
@@ -38,7 +38,7 @@ public open class GitVersioner internal constructor(
     @Deprecated("converted to property", replaceWith = ReplaceWith("versionCode"))
     public fun versionCode(): Int {
         logger?.warn("The GitVersioner.versionCode() method has been deprecated, " +
-                        "use the property GitVersioner.versionCode instead")
+                "use the property GitVersioner.versionCode instead")
         return versionCode
     }
 
@@ -61,7 +61,7 @@ public open class GitVersioner internal constructor(
     @Deprecated("converted to property", replaceWith = ReplaceWith("versionName"))
     public fun versionName(): String {
         logger?.warn("The GitVersioner.versionName() method has been deprecated, " +
-                        "use the property GitVersioner.versionName instead")
+                "use the property GitVersioner.versionName instead")
         return versionName
     }
 
@@ -152,6 +152,10 @@ public open class GitVersioner internal constructor(
      * whether git can be used to extract data
      */
     public val isGitProjectCorrectlyInitialized: Boolean = gitInfoExtractor.isGitProjectCorrectlyInitialized
+
+    @Deprecated(message = "renamed", replaceWith = ReplaceWith("isGitProjectCorrectlyInitialized"))
+    public val isGitProjectReady
+        get() = isGitProjectCorrectlyInitialized
 
 
     public val isHistoryShallowed: Boolean = gitInfoExtractor.isHistoryShallowed

--- a/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
+++ b/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
@@ -154,7 +154,7 @@ public open class GitVersioner internal constructor(
     public val isGitProjectCorrectlyInitialized: Boolean = gitInfoExtractor.isGitProjectCorrectlyInitialized
 
     @Deprecated(message = "renamed", replaceWith = ReplaceWith("isGitProjectCorrectlyInitialized"))
-    public val isGitProjectReady
+    public val isGitInitialized
         get() = isGitProjectCorrectlyInitialized
 
 

--- a/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersionerPlugin.kt
+++ b/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersionerPlugin.kt
@@ -25,7 +25,19 @@ public class GitVersionerPlugin : Plugin<Project> {
             doLast {
                 with(gitVersioner) {
 
-                    if (!gitVersioner.isGitInitialized) {
+                    if (!gitVersioner.isGitProjectCorrectlyInitialized) {
+
+                        val why = if (gitVersioner.isHistoryShallowed) {
+                            "WARNING: Git history is incomplete\n" +
+                                    "The gradle git version plugin requires the complete git history to calculate " +
+                                    "the version. The history is shallowed, therefore the version code would be incorrect.\n" +
+                                    "Please fetch the complete history with:\n" +
+                                    "\tgit fetch --unshallow"
+                        } else {
+                            "WARNING: git not initialized\n" +
+                                    "\tgit init"
+                        }
+
                         println("""
                         |
                         |GitVersioner Plugin
@@ -35,7 +47,7 @@ public class GitVersionerPlugin : Plugin<Project> {
                         |
                         |baseBranch: $baseBranch
                         |
-                        |git not initialized
+                        |$why
                         """.replaceIndentByMargin())
                         return@doLast
                     }

--- a/gitversioner/src/test/kotlin/com/pascalwelsch/gitversioner/GitVersionerTest.kt
+++ b/gitversioner/src/test/kotlin/com/pascalwelsch/gitversioner/GitVersionerTest.kt
@@ -496,7 +496,7 @@ class GitVersionerTest {
 
     @Test
     fun `no git repo`() {
-        val git = MockGitRepo(isGitProjectReady = false) // git initialized but nothing commited
+        val git = MockGitRepo(isGitProjectCorrectlyInitialized = false) // git initialized but nothing commited
         val versioner = GitVersioner(git)
 
         assertSoftly { softly ->

--- a/gitversioner/src/test/kotlin/com/pascalwelsch/gitversioner/MockGitRepo.kt
+++ b/gitversioner/src/test/kotlin/com/pascalwelsch/gitversioner/MockGitRepo.kt
@@ -14,7 +14,8 @@ open class MockGitRepo(
         val head: String? = null,
         val branchHeads: List<Pair<String /*sha1*/, String/*name*/>> = emptyList(),
         override val localChanges: LocalChanges = NO_CHANGES,
-        override val isGitProjectReady: Boolean = true
+        override val isGitProjectCorrectlyInitialized: Boolean = true,
+        override val isHistoryShallowed: Boolean = false
 ) : GitInfoExtractor {
 
     val headCommit: Commit? = if (head == null) null else
@@ -93,7 +94,8 @@ class GitInfoExtractorStub(
         override val currentSha1: String? = null,
         override val currentBranch: String? = null,
         override val localChanges: LocalChanges = NO_CHANGES,
-        override val isGitProjectReady: Boolean = true
+        override val isGitProjectCorrectlyInitialized: Boolean = true,
+        override val isHistoryShallowed: Boolean = false
 ) : GitInfoExtractor {
     override fun commitsUpTo(rev: String, args: String): List<String> {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.


### PR DESCRIPTION
This happens with `git clone X --depth=n` often used on CI