### PR TITLE
Ignore commits in baseBranch after branching off a feature branch

### DIFF
--- a/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
+++ b/gitversioner/src/main/kotlin/com/pascalwelsch/gitversioner/GitVersioner.kt
@@ -158,13 +158,9 @@ public open class GitVersioner internal constructor(
      */
     private val baseBranchCommits: List<String> by lazy {
         val baseCommits = gitInfoExtractor.commitsUpTo(baseBranch)
-        baseCommits.forEach { baseCommit ->
-            if (gitInfoExtractor.commitsToHead.contains(baseCommit)) {
-                return@lazy baseCommits
-            }
-        }
+        val headCommits = gitInfoExtractor.commitsToHead
 
-        return@lazy emptyList<String>()
+        baseCommits.filter { it in headCommits }
     }
 
     /**


### PR DESCRIPTION
Until now, new commits in `baseBranch` where incrementing the version although the content of a commit in `HEAD` (`featureBranch`) hasn’t changed and doesn’t include latest changes in `baseBranch`

This change is also present in [gitRevision](https://github.com/passsy/git-revision/commit/1617c0710d8dfb2c19db225d648ba143bba0995c) 