### PR TITLE
Support shallow clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ versionName 2376-upgrade_gradle_4.4.1+3
 versionCode 2376
 ```
 
-While working on your features when you have uncommited changes `files changed: 1, additions(+): 2, deletions(-): 0`.
+While working on your features when you have uncommitted changes `files changed: 1, additions(+): 2, deletions(-): 0`.
 ```
 versionName 2376-upgrade_gradle_4.4.1+3-SNAPSHOT(1 +2 -0)
 versionCode 2376

--- a/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GitVersioner.kt
+++ b/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GitVersioner.kt
@@ -37,10 +37,8 @@ public open class GitVersioner internal constructor(
      */
     @Deprecated("converted to property", replaceWith = ReplaceWith("versionCode"))
     public fun versionCode(): Int {
-        logger?.warn(
-            "The GitVersioner.versionCode() method has been deprecated, " +
-                    "use the property GitVersioner.versionCode instead"
-        )
+        logger?.warn("The GitVersioner.versionCode() method has been deprecated, " +
+                "use the property GitVersioner.versionCode instead")
         return versionCode
     }
 
@@ -67,10 +65,8 @@ public open class GitVersioner internal constructor(
      */
     @Deprecated("converted to property", replaceWith = ReplaceWith("versionName"))
     public fun versionName(): String {
-        logger?.warn(
-            "The GitVersioner.versionName() method has been deprecated, " +
-                    "use the property GitVersioner.versionName instead"
-        )
+        logger?.warn("The GitVersioner.versionName() method has been deprecated, " +
+                "use the property GitVersioner.versionName instead")
         return versionName
     }
 

--- a/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GitVersioner.kt
+++ b/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GitVersioner.kt
@@ -37,8 +37,10 @@ public open class GitVersioner internal constructor(
      */
     @Deprecated("converted to property", replaceWith = ReplaceWith("versionCode"))
     public fun versionCode(): Int {
-        logger?.warn("The GitVersioner.versionCode() method has been deprecated, " +
-                "use the property GitVersioner.versionCode instead")
+        logger?.warn(
+            "The GitVersioner.versionCode() method has been deprecated, " +
+                    "use the property GitVersioner.versionCode instead"
+        )
         return versionCode
     }
 
@@ -65,8 +67,10 @@ public open class GitVersioner internal constructor(
      */
     @Deprecated("converted to property", replaceWith = ReplaceWith("versionName"))
     public fun versionName(): String {
-        logger?.warn("The GitVersioner.versionName() method has been deprecated, " +
-                "use the property GitVersioner.versionName instead")
+        logger?.warn(
+            "The GitVersioner.versionName() method has been deprecated, " +
+                    "use the property GitVersioner.versionName instead"
+        )
         return versionName
     }
 
@@ -254,7 +258,7 @@ public open class GitVersioner internal constructor(
         @JvmStatic
         public val DEFAULT_FORMATTER: ((GitVersioner) -> CharSequence) = { versioner ->
             with(versioner) {
-                val sb = StringBuilder(if(isHistoryShallowed) "shallowed" else versioner.versionCode.toString())
+                val sb = StringBuilder(if (isHistoryShallowed) "shallowed" else versioner.versionCode.toString())
                 val hasCommits = featureBranchCommitCount > 0 || baseBranchCommitCount > 0
                 if (baseBranch != branchName && (hasCommits || isHistoryShallowed)) {
                     // add branch identifier for

--- a/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GitVersionerPlugin.kt
+++ b/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GitVersionerPlugin.kt
@@ -28,7 +28,20 @@ public class GitVersionerPlugin : Plugin<Project> {
             doLast {
                 with(gitVersioner) {
 
-                    if (!gitVersioner.isGitInitialized) {
+                    if (!gitVersioner.isGitProjectCorrectlyInitialized) {
+
+                        val why = if (gitVersioner.isHistoryShallowed) {
+                            "WARNING: Git history is incomplete (shallow clone)\n" +
+                                    "The com.pascalwelsch.gitversioner gradle plugin requires the complete git history to calculate " +
+                                    "the version. The history is shallowed, therefore the version code would be incorrect.\n" +
+                                    "Default values versionName: 'undefined', versionCode: 1 are used instead.\n\n" +
+                                    "Please fetch the complete history with:\n" +
+                                    "\tgit fetch --unshallow"
+                        } else {
+                            "WARNING: git not initialized. Run:\n" +
+                                    "\tgit init"
+                        }
+
                         println(
                             """
                         |
@@ -39,7 +52,7 @@ public class GitVersionerPlugin : Plugin<Project> {
                         |
                         |baseBranch: $baseBranch
                         |
-                        |git not initialized
+                        |$why
                         """.replaceIndentByMargin()
                         )
                         return@doLast

--- a/gitversioner/src/test/java/com/pascalwelsch/gitversioner/GitVersionerTest.kt
+++ b/gitversioner/src/test/java/com/pascalwelsch/gitversioner/GitVersionerTest.kt
@@ -244,7 +244,7 @@ class GitVersionerTest {
             Commit(sha1 = "a", parent = null, date = 150_000_000)
         )
 
-        val git = MockGitRepo(graph, "X", listOf("e" to "master", "X" to "orphan"))
+        val git = MockGitRepo(graph, "X", branchHeads = listOf("e" to "master", "X" to "orphan"))
         val versioner = GitVersioner(git)
 
         assertSoftly { softly ->
@@ -299,7 +299,7 @@ class GitVersionerTest {
     }
 
     @Test
-    fun `one commit`() {
+    fun `first commit - no parent`() {
         val graph = listOf(
             Commit(sha1 = "X", parent = null, date = 150_006_000) // <-- master, HEAD
         )
@@ -501,7 +501,7 @@ class GitVersionerTest {
 
     @Test
     fun `no git repo`() {
-        val git = MockGitRepo(isGitProjectReady = false) // git initialized but nothing commited
+        val git = MockGitRepo(isGitWorking = false) // git initialized but nothing committed
         val versioner = GitVersioner(git)
 
         assertSoftly { softly ->
@@ -545,7 +545,7 @@ class GitVersionerTest {
     fun `no commits - local changes`() {
 
         val localChanges = LocalChanges(3, 5, 7)
-        val git = MockGitRepo(localChanges = localChanges) // git initialized but nothing commited
+        val git = MockGitRepo(localChanges = localChanges) // git initialized but nothing committed
         val versioner = GitVersioner(git)
 
         assertSoftly { softly ->
@@ -803,7 +803,7 @@ class GitVersionerTest {
     }
 
     @Test
-    fun `default - receice default branchname from ci`() {
+    fun `default - receive default branch name from ci`() {
         val graph = listOf(
             Commit(sha1 = "X", parent = "j", date = 150_010_000), // <-- HEAD
             Commit(sha1 = "j", parent = "i", date = 150_009_000),

--- a/gitversioner/src/test/java/com/pascalwelsch/gitversioner/ShallowCloneTest.kt
+++ b/gitversioner/src/test/java/com/pascalwelsch/gitversioner/ShallowCloneTest.kt
@@ -1,0 +1,348 @@
+package com.pascalwelsch.gitversioner
+
+import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.junit.*
+import org.junit.runner.*
+import org.junit.runners.*
+import java.util.concurrent.TimeUnit
+
+@RunWith(JUnit4::class)
+class ShallowCloneTest {
+
+    @Test
+    fun `default - clean on default branch master`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- master, HEAD
+        )
+
+        val git = MockGitRepo(graph, "X", listOf("X" to "master"), isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
+        }
+    }
+
+    @Test
+    fun `default - with local changes - addSnapshot false`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- master, HEAD
+        )
+
+        val localChanges = LocalChanges(3, 5, 7)
+        val git = MockGitRepo(graph, "X", listOf("X" to "master"), localChanges, isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+        versioner.addSnapshot = false
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed(3 +5 -7)")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(localChanges)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
+        }
+    }
+
+    @Test
+    fun `default - with local changes - addLocalChangesDetails false`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- master, HEAD
+        )
+        val localChanges = LocalChanges(3, 5, 7)
+        val git = MockGitRepo(graph, "X", listOf("X" to "master"), localChanges, isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+        versioner.addLocalChangesDetails = false
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-SNAPSHOT")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(localChanges)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
+        }
+    }
+
+    @Test
+    fun `default - without local changes information`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- master, HEAD
+        )
+
+        val localChanges = LocalChanges(3, 5, 7)
+        val git = MockGitRepo(graph, "X", listOf("X" to "master"), localChanges, isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+        versioner.addLocalChangesDetails = false
+        versioner.addSnapshot = false
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(localChanges)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
+        }
+    }
+
+    @Test
+    fun `default - with local changes`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- master, HEAD
+        )
+
+        val localChanges = LocalChanges(3, 5, 7)
+        val git = MockGitRepo(graph, "X", listOf("X" to "master"), localChanges, isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-SNAPSHOT(3 +5 -7)")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(localChanges)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
+        }
+    }
+
+    @Test
+    fun `base branch not in history`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- master, HEAD
+        )
+
+        val git = MockGitRepo(graph, "X", listOf("X" to "master"), isHistoryShallowed = true)
+        val versioner = GitVersioner(git).apply {
+            baseBranch = "develop"
+        }
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-master")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("develop")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+
+            // no commit in both HEAD history and develop because develop is not part of the graph
+            softly.assertThat(versioner.featureBranchOriginCommit).isNull()
+        }
+    }
+
+    @Test
+    fun `on orphan initial commit`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = null, date = 150_010_000) // <-- HEAD, orphan
+        )
+
+        val git = MockGitRepo(graph, "X", branchHeads = listOf("X" to "orphan"), isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-orphan")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("orphan")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isNull()
+        }
+    }
+
+    @Test
+    fun `on orphan few commits`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "b'", date = 150_030_000) // <-- HEAD, feature/x
+        )
+
+        val git = MockGitRepo(graph, "X", listOf("X" to "feature/x"), isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-x")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("feature/x")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isNull()
+        }
+    }
+
+    @Test
+    fun `first commit - no parent`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = null, date = 150_006_000) // <-- master, HEAD
+        )
+
+        val git = MockGitRepo(graph, "X", listOf("X" to "master"), isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
+        }
+    }
+
+    @Test
+    fun `short sha1`() {
+        val graph = listOf(
+            Commit(sha1 = "abcdefghijkl", parent = null, date = 150_006_000) // <-- master, HEAD
+        )
+
+        val git = MockGitRepo(graph, "abcdefghijkl", listOf("abcdefghijkl" to "master"), isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("master")
+            softly.assertThat(versioner.currentSha1).isEqualTo("abcdefghijkl")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.initialCommit).isNull()
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("abcdefghijkl")
+        }
+
+        assertThat(versioner.currentSha1Short).isEqualTo("abcdefg").hasSize(7)
+    }
+
+    @Test
+    fun `no commits`() {
+        val git = MockGitRepo(isHistoryShallowed = true) // git initialized but nothing committed
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-undefined")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isNull()
+            softly.assertThat(versioner.currentSha1).isNull()
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isNull()
+        }
+    }
+
+    @Test
+    fun `no branch name - sha1 fallback`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- HEAD
+        )
+
+        val git = MockGitRepo(graph, "X", isHistoryShallowed = true)
+        val versioner = GitVersioner(git)
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-X")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isNull()
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isNull()
+        }
+    }
+
+    @Test
+    fun `default - branchname from ci`() {
+        val graph = listOf(
+            Commit(sha1 = "X", parent = "j", date = 150_010_000) // <-- HEAD, master
+        )
+
+        val git = object : MockGitRepo(graph, "X", listOf("X" to "master"), isHistoryShallowed = true) {
+            // explicitly checked out sha1 not branch
+            override val currentBranch: String? = null
+        }
+        val versioner = GitVersioner(git)
+        versioner.ciBranchNameProvider = { "nameFromCi" }
+
+        assertSoftly { softly ->
+            softly.assertThat(versioner.versionCode).isEqualTo(1)
+            softly.assertThat(versioner.versionName).isEqualTo("shallowed-nameFromCi")
+            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(0)
+            softly.assertThat(versioner.branchName).isEqualTo("nameFromCi")
+            softly.assertThat(versioner.currentSha1).isEqualTo("X")
+            softly.assertThat(versioner.baseBranch).isEqualTo("master")
+            softly.assertThat(versioner.localChanges).isEqualTo(NO_CHANGES)
+            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
+            softly.assertThat(versioner.timeComponent).isEqualTo(0)
+            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
+        }
+    }
+
+}

--- a/gitversioner/src/test/java/com/pascalwelsch/gitversioner/ShallowCloneTest.kt
+++ b/gitversioner/src/test/java/com/pascalwelsch/gitversioner/ShallowCloneTest.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.*
 import org.junit.runner.*
 import org.junit.runners.*
-import java.util.concurrent.TimeUnit
 
 @RunWith(JUnit4::class)
 class ShallowCloneTest {
@@ -344,5 +343,4 @@ class ShallowCloneTest {
             softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("X")
         }
     }
-
 }


### PR DESCRIPTION
Rebased #4 and added tests.

Fixes #4 

Additionally, I changed the behaviour of the `ShellGitInfoExtractor`. It now throws on errors and doesn't manually check if git is initialized and working. Those checks have been moved into the `GitVersioner`. This makes sure they are covered with unit tests as well.