### PR TITLE
Remove special characters from branch name

### DIFF
--- a/gitversioner/src/test/java/com/pascalwelsch/gitversioner/MockGitRepo.kt
+++ b/gitversioner/src/test/java/com/pascalwelsch/gitversioner/MockGitRepo.kt
@@ -100,20 +100,21 @@ class GitInfoExtractorStub(
     override val currentBranch: String? = null,
     override val localChanges: LocalChanges = NO_CHANGES,
     override val isGitWorking: Boolean = true,
-    override val isHistoryShallowed: Boolean = false
+    override val isHistoryShallowed: Boolean = false,
+    val commits: List<String> = emptyList()
 ) : GitInfoExtractor {
 
     override fun commitsUpTo(rev: String, args: String): List<String> {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        return commits
     }
 
     override val initialCommitDate: Long
-        get() = TODO("not implemented")
+        get() = 0L
 
     override val commitsToHead: List<String>
-        get() = TODO("not implemented")
+        get() = commits
 
     override fun commitDate(rev: String): Long {
-        TODO("not implemented")
+        return 0L
     }
 }

--- a/gitversioner/src/test/java/com/pascalwelsch/gitversioner/PrefixedBranchTest.kt
+++ b/gitversioner/src/test/java/com/pascalwelsch/gitversioner/PrefixedBranchTest.kt
@@ -1,6 +1,6 @@
 package com.pascalwelsch.gitversioner
 
-import org.assertj.core.api.SoftAssertions
+import org.assertj.core.api.Assertions.*
 import org.junit.*
 import org.junit.runner.*
 import org.junit.runners.*
@@ -9,74 +9,27 @@ import org.junit.runners.*
 class PrefixedBranchTest {
 
     @Test
-    fun `on branch with one prefix - few commits - local changes`() {
-        val graph = listOf(
-            Commit(sha1 = "X", parent = "j", date = 150_010_000), // <-- bugfix/bug_123, HEAD
-            Commit(sha1 = "j", parent = "i", date = 150_009_000),
-            Commit(sha1 = "i", parent = "h", date = 150_008_000),
-            Commit(sha1 = "h", parent = "g", date = 150_007_000),
-            Commit(sha1 = "g", parent = "f", date = 150_006_000), // <-- master
-            Commit(sha1 = "f", parent = "e", date = 150_005_000),
-            Commit(sha1 = "e", parent = "d", date = 150_004_000),
-            Commit(sha1 = "d", parent = "c", date = 150_003_000),
-            Commit(sha1 = "c", parent = "b", date = 150_002_000),
-            Commit(sha1 = "b", parent = "a", date = 150_001_000),
-            Commit(sha1 = "a", parent = null, date = 150_000_000)
-        )
-
-        val localChanges = LocalChanges(3, 5, 7)
-        val git = MockGitRepo(graph, "X", listOf("g" to "master", "X" to "bugfix/bug_123"), localChanges)
-        val versioner = GitVersioner(git)
-
-        SoftAssertions.assertSoftly { softly ->
-            softly.assertThat(versioner.versionCode).isEqualTo(7)
-            softly.assertThat(versioner.versionName).isEqualTo("7-bug_123+4-SNAPSHOT(3 +5 -7)")
-            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(7)
-            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(4)
-            softly.assertThat(versioner.branchName).isEqualTo("bugfix/bug_123")
-            softly.assertThat(versioner.currentSha1).isEqualTo("X")
-            softly.assertThat(versioner.baseBranch).isEqualTo("master")
-            softly.assertThat(versioner.initialCommit).isEqualTo("a")
-            softly.assertThat(versioner.localChanges).isEqualTo(localChanges)
-            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
-            softly.assertThat(versioner.timeComponent).isEqualTo(0)
-            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("g")
-        }
+    fun `replace special characters`() {
+        assertThat(versionNameForBranch("craz+y-n=,a^m;e")).isEqualTo("3-craz_y-n_a_m_e")
     }
 
     @Test
-    fun `on branch with multiple prefixes - few commits - local changes`() {
-        val graph = listOf(
-            Commit(sha1 = "X", parent = "j", date = 150_010_000), // <-- bugfix/something/bug_123, HEAD
-            Commit(sha1 = "j", parent = "i", date = 150_009_000),
-            Commit(sha1 = "i", parent = "h", date = 150_008_000),
-            Commit(sha1 = "h", parent = "g", date = 150_007_000),
-            Commit(sha1 = "g", parent = "f", date = 150_006_000), // <-- master
-            Commit(sha1 = "f", parent = "e", date = 150_005_000),
-            Commit(sha1 = "e", parent = "d", date = 150_004_000),
-            Commit(sha1 = "d", parent = "c", date = 150_003_000),
-            Commit(sha1 = "c", parent = "b", date = 150_002_000),
-            Commit(sha1 = "b", parent = "a", date = 150_001_000),
-            Commit(sha1 = "a", parent = null, date = 150_000_000)
-        )
-
-        val localChanges = LocalChanges(3, 5, 7)
-        val git = MockGitRepo(graph, "X", listOf("g" to "master", "X" to "bugfix/something/bug_123"), localChanges)
-        val versioner = GitVersioner(git)
-
-        SoftAssertions.assertSoftly { softly ->
-            softly.assertThat(versioner.versionCode).isEqualTo(7)
-            softly.assertThat(versioner.versionName).isEqualTo("7-bug_123+4-SNAPSHOT(3 +5 -7)")
-            softly.assertThat(versioner.baseBranchCommitCount).isEqualTo(7)
-            softly.assertThat(versioner.featureBranchCommitCount).isEqualTo(4)
-            softly.assertThat(versioner.branchName).isEqualTo("bugfix/something/bug_123")
-            softly.assertThat(versioner.currentSha1).isEqualTo("X")
-            softly.assertThat(versioner.baseBranch).isEqualTo("master")
-            softly.assertThat(versioner.initialCommit).isEqualTo("a")
-            softly.assertThat(versioner.localChanges).isEqualTo(localChanges)
-            softly.assertThat(versioner.yearFactor).isEqualTo(1000)
-            softly.assertThat(versioner.timeComponent).isEqualTo(0)
-            softly.assertThat(versioner.featureBranchOriginCommit).isEqualTo("g")
-        }
+    fun `remove prefix + replace special characters`() {
+        assertThat(versionNameForBranch("feature/craz+y-n=,a^m;e")).isEqualTo("3-craz_y-n_a_m_e")
     }
+
+    @Test
+    fun `remove prefix`() {
+        assertThat(versionNameForBranch("bugfix/bug_123")).isEqualTo("3-bug_123")
+    }
+
+    @Test
+    fun `remove only first prefix`() {
+        assertThat(versionNameForBranch("bugfix/something/bug_123")).isEqualTo("3-something_bug_123")
+    }
+}
+
+private fun versionNameForBranch(branchName: String): String {
+    val versioner = GitVersioner(GitInfoExtractorStub(commits = listOf("a", "b", "c"), currentBranch = branchName))
+    return versioner.versionName
 }


### PR DESCRIPTION
Removes all special characters (except for `_` and `-`) from the branch name

Unlike initially proposed in #17, the plugin now removes the first prefix but leaves all other slash-separated parts.

`bugfix/something/bug_123` -> `something_bug_123`