### PR TITLE
annotate gitVersioner property

### DIFF
--- a/gitversioner/build.gradle
+++ b/gitversioner/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'kotlin'
 apply plugin: "guru.stefma.artifacts"
 
 group = 'com.pascalwelsch.gitversioner'
-version = '0.5.0'
+version = '0.5.1'
 
 dependencies {
     compile gradleApi()

--- a/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GenerateGitVersionName.kt
+++ b/gitversioner/src/main/java/com/pascalwelsch/gitversioner/GenerateGitVersionName.kt
@@ -1,12 +1,14 @@
 package com.pascalwelsch.gitversioner
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.util.Properties
 
 internal open class GenerateGitVersionName : DefaultTask() {
 
-    internal lateinit var gitVersioner: GitVersioner
+    @Internal
+    lateinit var gitVersioner: GitVersioner
 
     @TaskAction
     fun generate() {


### PR DESCRIPTION
Using this plugin with gradle7 and kotlin dsl results in this error message:

- Type 'GenerateGitVersionName' property 'gitVersioner$gitversioner' is missing an input or output annotation.

The PR adds the missing annotation.